### PR TITLE
Change: `ascii.isAlpha` -> `ascii.isAlphanumeric`

### DIFF
--- a/lib/input.zig
+++ b/lib/input.zig
@@ -157,7 +157,7 @@ const InputParser = struct {
         // This may be either a M-[a-z] code, or we accidentally received an
         // escape key press and a letter key press together. There is literally
         // no way to differentiate. However the second case is less likely.
-        if (ascii.isAlpha(self.bytes.?[1]) and ascii.isLower(self.bytes.?[1])) {
+        if (ascii.isAlphanumeric(self.bytes.?[1]) and ascii.isLower(self.bytes.?[1])) {
             defer self.advanceBufferBy("\x1Ba".len);
             return Input{ .content = .{ .codepoint = self.bytes.?[1] }, .mod_alt = true };
         }


### PR DESCRIPTION
`std.ascii.isAlpha` is deprecated. Instead using `std.ascii.isAlphanumeric`.

The [master std](https://ziglang.org/documentation/master/std/#root;ascii) library doesnt have `ascii.isAlpha`, it was deprecated and removed as seen in the [0.10.0 documentation](https://ziglang.org/documentation/0.10.0/std/#root;ascii). 